### PR TITLE
[Smac Planner] Fix node index overflow for huge map

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -55,7 +55,7 @@ public:
   typedef typename NodeT::Coordinates Coordinates;
   typedef typename NodeT::CoordinateVector CoordinateVector;
   typedef typename NodeVector::iterator NeighborIterator;
-  typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
+  typedef std::function<bool (const uint64_t &, NodeT * &)> NodeGetter;
 
   /**
    * @struct nav2_smac_planner::NodeComparator
@@ -210,7 +210,7 @@ protected:
    * @brief Adds node to graph
    * @param index Node index to add
    */
-  inline NodePtr addToGraph(const unsigned int & index);
+  inline NodePtr addToGraph(const uint64_t & index);
 
   /**
    * @brief Check if this node is the goal node

--- a/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion.hpp
@@ -35,7 +35,7 @@ class AnalyticExpansion
 public:
   typedef NodeT * NodePtr;
   typedef typename NodeT::Coordinates Coordinates;
-  typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
+  typedef std::function<bool (const uint64_t &, NodeT * &)> NodeGetter;
 
   /**
    * @struct nav2_smac_planner::AnalyticExpansion::AnalyticExpansionNodes

--- a/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
@@ -89,7 +89,7 @@ public:
    * @return boolean if in collision or not.
    */
   bool inCollision(
-    const unsigned int & i,
+    const uint64_t & i,
     const bool & traverse_unknown);
 
   /**

--- a/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
@@ -62,7 +62,7 @@ public:
    * @brief A constructor for nav2_smac_planner::Node2D
    * @param index The index of this node for self-reference
    */
-  explicit Node2D(const unsigned int index);
+  explicit Node2D(const uint64_t index);
 
   /**
    * @brief A destructor for nav2_smac_planner::Node2D
@@ -158,7 +158,7 @@ public:
    * @brief Gets cell index
    * @return Reference to cell index
    */
-  inline unsigned int getIndex()
+  inline uint64_t getIndex()
   {
     return _index;
   }
@@ -185,10 +185,11 @@ public:
    * @param width width of costmap
    * @return index
    */
-  static inline unsigned int getIndex(
+  static inline uint64_t getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & width)
   {
-    return x + y * width;
+    return static_cast<uint64_t>(x) + static_cast<uint64_t>(y) *
+           static_cast<uint64_t>(width);
   }
 
   /**
@@ -199,7 +200,7 @@ public:
    * @return coordinates of point
    */
   static inline Coordinates getCoords(
-    const unsigned int & index, const unsigned int & width, const unsigned int & angles)
+    const uint64_t & index, const unsigned int & width, const unsigned int & angles)
   {
     if (angles != 1) {
       throw std::runtime_error("Node type Node2D does not have a valid angle quantization.");
@@ -213,7 +214,7 @@ public:
    * @param Index Index of point
    * @return coordinates of point
    */
-  static inline Coordinates getCoords(const unsigned int & index)
+  static inline Coordinates getCoords(const uint64_t & index)
   {
     const unsigned int & size_x = _neighbors_grid_offsets[3];
     return Coordinates(index % size_x, index / size_x);
@@ -253,7 +254,8 @@ public:
    * @param neighbors Vector of neighbors to be filled
    */
   void getNeighbors(
-    std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> & validity_checker,
+    std::function<bool(const uint64_t &,
+    nav2_smac_planner::Node2D * &)> & validity_checker,
     GridCollisionChecker * collision_checker,
     const bool & traverse_unknown,
     NodeVector & neighbors);
@@ -272,7 +274,7 @@ public:
 private:
   float _cell_cost;
   float _accumulated_cost;
-  unsigned int _index;
+  uint64_t _index;
   bool _was_visited;
   bool _is_queued;
 };

--- a/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
@@ -49,7 +49,7 @@ public:
    * @brief A constructor for nav2_smac_planner::NodeBasic
    * @param index The index of this node for self-reference
    */
-  explicit NodeBasic(const unsigned int index)
+  explicit NodeBasic(const uint64_t index)
   : index(index),
     graph_node_ptr(nullptr)
   {
@@ -73,7 +73,8 @@ public:
   typename NodeT::Coordinates pose;  // Used by NodeHybrid and NodeLattice
   NodeT * graph_node_ptr;
   MotionPrimitive * prim_ptr;  // Used by NodeLattice
-  unsigned int index, motion_index;
+  uint64_t index;
+  unsigned int motion_index;
   bool backward;
   TurnDirection turn_dir;
 };

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -40,7 +40,7 @@ namespace nav2_smac_planner
 typedef std::vector<float> LookupTable;
 typedef std::pair<double, double> TrigValues;
 
-typedef std::pair<float, unsigned int> ObstacleHeuristicElement;
+typedef std::pair<float, uint64_t> ObstacleHeuristicElement;
 struct ObstacleHeuristicComparator
 {
   bool operator()(const ObstacleHeuristicElement & a, const ObstacleHeuristicElement & b) const
@@ -184,7 +184,7 @@ public:
    * @brief A constructor for nav2_smac_planner::NodeHybrid
    * @param index The index of this node for self-reference
    */
-  explicit NodeHybrid(const unsigned int index);
+  explicit NodeHybrid(const uint64_t index);
 
   /**
    * @brief A destructor for nav2_smac_planner::NodeHybrid
@@ -291,7 +291,7 @@ public:
    * @brief Gets cell index
    * @return Reference to cell index
    */
-  inline unsigned int getIndex()
+  inline uint64_t getIndex()
   {
     return _index;
   }
@@ -319,11 +319,14 @@ public:
    * @param angle_quantization Number of theta bins
    * @return Index
    */
-  static inline unsigned int getIndex(
+  static inline uint64_t getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & angle,
     const unsigned int & width, const unsigned int & angle_quantization)
   {
-    return angle + x * angle_quantization + y * width * angle_quantization;
+    return static_cast<uint64_t>(angle) + static_cast<uint64_t>(x) *
+           static_cast<uint64_t>(angle_quantization) +
+           static_cast<uint64_t>(y) * static_cast<uint64_t>(width) *
+           static_cast<uint64_t>(angle_quantization);
   }
 
   /**
@@ -333,7 +336,7 @@ public:
    * @param angle Theta coordinate of point
    * @return Index
    */
-  static inline unsigned int getIndex(
+  static inline uint64_t getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & angle)
   {
     return getIndex(
@@ -349,7 +352,7 @@ public:
    * @return Coordinates
    */
   static inline Coordinates getCoords(
-    const unsigned int & index,
+    const uint64_t & index,
     const unsigned int & width, const unsigned int & angle_quantization)
   {
     return Coordinates(
@@ -447,7 +450,8 @@ public:
    * @param neighbors Vector of neighbors to be filled
    */
   void getNeighbors(
-    std::function<bool(const unsigned int &, nav2_smac_planner::NodeHybrid * &)> & validity_checker,
+    std::function<bool(const uint64_t &,
+    nav2_smac_planner::NodeHybrid * &)> & validity_checker,
     GridCollisionChecker * collision_checker,
     const bool & traverse_unknown,
     NodeVector & neighbors);
@@ -478,7 +482,7 @@ public:
 private:
   float _cell_cost;
   float _accumulated_cost;
-  unsigned int _index;
+  uint64_t _index;
   bool _was_visited;
   unsigned int _motion_primitive_index;
   TurnDirection _turn_dir;

--- a/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
@@ -132,7 +132,7 @@ public:
    * @brief A constructor for nav2_smac_planner::NodeLattice
    * @param index The index of this node for self-reference
    */
-  explicit NodeLattice(const unsigned int index);
+  explicit NodeLattice(const uint64_t index);
 
   /**
    * @brief A destructor for nav2_smac_planner::NodeLattice
@@ -229,7 +229,7 @@ public:
    * @brief Gets cell index
    * @return Reference to cell index
    */
-  inline unsigned int getIndex()
+  inline uint64_t getIndex()
   {
     return _index;
   }
@@ -281,7 +281,7 @@ public:
    * @param angle Theta coordinate of point
    * @return Index
    */
-  static inline unsigned int getIndex(
+  static inline uint64_t getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & angle)
   {
     // Hybrid-A* and State Lattice share a coordinate system
@@ -298,7 +298,7 @@ public:
    * @return Coordinates
    */
   static inline Coordinates getCoords(
-    const unsigned int & index,
+    const uint64_t & index,
     const unsigned int & width, const unsigned int & angle_quantization)
   {
     // Hybrid-A* and State Lattice share a coordinate system
@@ -396,7 +396,7 @@ public:
    * @param neighbors Vector of neighbors to be filled
    */
   void getNeighbors(
-    std::function<bool(const unsigned int &,
+    std::function<bool(const uint64_t &,
     nav2_smac_planner::NodeLattice * &)> & validity_checker,
     GridCollisionChecker * collision_checker,
     const bool & traverse_unknown,
@@ -425,7 +425,7 @@ public:
 private:
   float _cell_cost;
   float _accumulated_cost;
-  unsigned int _index;
+  uint64_t _index;
   bool _was_visited;
   MotionPrimitive * _motion_primitive;
   bool _backwards;

--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -26,7 +26,7 @@
 namespace nav2_smac_planner
 {
 
-typedef std::pair<float, unsigned int> NodeHeuristicPair;
+typedef std::pair<float, uint64_t> NodeHeuristicPair;
 
 /**
  * @struct nav2_smac_planner::SearchInfo

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -120,7 +120,7 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
 
 template<typename NodeT>
 typename AStarAlgorithm<NodeT>::NodePtr AStarAlgorithm<NodeT>::addToGraph(
-  const unsigned int & index)
+  const uint64_t & index)
 {
   auto iter = _graph.find(index);
   if (iter != _graph.end()) {
@@ -287,9 +287,11 @@ bool AStarAlgorithm<NodeT>::createPath(
   int closest_distance = std::numeric_limits<int>::max();
 
   // Given an index, return a node ptr reference if its collision-free and valid
-  const unsigned int max_index = getSizeX() * getSizeY() * getSizeDim3();
+  const uint64_t max_index = static_cast<uint64_t>(getSizeX()) *
+    static_cast<uint64_t>(getSizeY()) *
+    static_cast<uint64_t>(getSizeDim3());
   NodeGetter neighborGetter =
-    [&, this](const unsigned int & index, NodePtr & neighbor_rtn) -> bool
+    [&, this](const uint64_t & index, NodePtr & neighbor_rtn) -> bool
     {
       if (index >= max_index) {
         return false;

--- a/nav2_smac_planner/src/analytic_expansion.cpp
+++ b/nav2_smac_planner/src/analytic_expansion.cpp
@@ -201,7 +201,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
   // Pre-allocate
   NodePtr prev(node);
-  unsigned int index = 0;
+  uint64_t index = 0;
   NodePtr next(nullptr);
   float angle = 0.0;
   Coordinates proposed_coordinates;

--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -174,7 +174,7 @@ bool GridCollisionChecker::inCollision(
 }
 
 bool GridCollisionChecker::inCollision(
-  const unsigned int & i,
+  const uint64_t & i,
   const bool & traverse_unknown)
 {
   footprint_cost_ = costmap_->getCost(i);

--- a/nav2_smac_planner/src/node_2d.cpp
+++ b/nav2_smac_planner/src/node_2d.cpp
@@ -25,7 +25,7 @@ namespace nav2_smac_planner
 std::vector<int> Node2D::_neighbors_grid_offsets;
 float Node2D::cost_travel_multiplier = 2.0;
 
-Node2D::Node2D(const unsigned int index)
+Node2D::Node2D(const uint64_t index)
 : parent(nullptr),
   _cell_cost(std::numeric_limits<float>::quiet_NaN()),
   _accumulated_cost(std::numeric_limits<float>::max()),
@@ -108,7 +108,8 @@ void Node2D::initMotionModel(
 }
 
 void Node2D::getNeighbors(
-  std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> & NeighborGetter,
+  std::function<bool(const uint64_t &,
+  nav2_smac_planner::Node2D * &)> & NeighborGetter,
   GridCollisionChecker * collision_checker,
   const bool & traverse_unknown,
   NodeVector & neighbors)
@@ -124,9 +125,9 @@ void Node2D::getNeighbors(
   // 100 100 100   where lower-middle '100' is visited with same cost by both bottom '50' nodes
   // Therefore, it is valuable to have some low-potential across the entire map
   // rather than a small inflation around the obstacles
-  int index;
+  uint64_t index;
   NodePtr neighbor;
-  int node_i = this->getIndex();
+  uint64_t node_i = this->getIndex();
   const Coordinates parent = getCoords(this->getIndex());
   Coordinates child;
 

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -338,7 +338,7 @@ float HybridMotionTable::getAngleFromBin(const unsigned int & bin_idx)
   return bin_idx * bin_size;
 }
 
-NodeHybrid::NodeHybrid(const unsigned int index)
+NodeHybrid::NodeHybrid(const uint64_t index)
 : parent(nullptr),
   pose(0.0f, 0.0f, 0.0f),
   _cell_cost(std::numeric_limits<float>::quiet_NaN()),
@@ -468,7 +468,7 @@ void NodeHybrid::initMotionModel(
 }
 
 inline float distanceHeuristic2D(
-  const unsigned int idx, const unsigned int size_x,
+  const uint64_t idx, const unsigned int size_x,
   const unsigned int target_x, const unsigned int target_y)
 {
   int dx = static_cast<int>(idx % size_x) - static_cast<int>(target_x);
@@ -490,7 +490,7 @@ void NodeHybrid::resetObstacleHeuristic(
   auto costmap = costmap_ros->getCostmap();
 
   // Clear lookup table
-  unsigned int size = 0u;
+  uint64_t size = 0u;
   unsigned int size_x = 0u;
   if (motion_table.downsample_obstacle_heuristic) {
     size_x = ceil(static_cast<float>(costmap->getSizeInCellsX()) / 2.0f);
@@ -507,7 +507,7 @@ void NodeHybrid::resetObstacleHeuristic(
       obstacle_heuristic_lookup_table.begin(),
       obstacle_heuristic_lookup_table.end(), 0.0f);
   } else {
-    unsigned int obstacle_size = obstacle_heuristic_lookup_table.size();
+    uint64_t obstacle_size = obstacle_heuristic_lookup_table.size();
     obstacle_heuristic_lookup_table.resize(size, 0.0f);
     // must reset values for non-constructed indices
     std::fill_n(
@@ -518,7 +518,7 @@ void NodeHybrid::resetObstacleHeuristic(
   obstacle_heuristic_queue.reserve(size);
 
   // Set initial goal point to queue from. Divided by 2 due to downsampled costmap.
-  unsigned int goal_index;
+  uint64_t goal_index;
   if (motion_table.downsample_obstacle_heuristic) {
     goal_index = floor(goal_y / 2.0f) * size_x + floor(goal_x / 2.0f);
   } else {
@@ -585,7 +585,7 @@ float NodeHybrid::getObstacleHeuristic(
     start_x = floor(node_coords.x);
   }
 
-  const unsigned int start_index = start_y * size_x + start_x;
+  const uint64_t start_index = start_y * size_x + start_x;
   const float & requested_node_cost = obstacle_heuristic_lookup_table[start_index];
   if (requested_node_cost > 0.0f) {
     // costs are doubled due to downsampling
@@ -611,8 +611,8 @@ float NodeHybrid::getObstacleHeuristic(
   const int size_x_int = static_cast<int>(size_x);
   const float sqrt2 = sqrtf(2.0f);
   float c_cost, cost, travel_cost, new_cost, existing_cost;
-  unsigned int idx, mx, my;
-  unsigned int new_idx = 0;
+  unsigned int mx, my;
+  uint64_t idx, new_idx = 0;
 
   const std::vector<int> neighborhood = {1, -1,  // left right
     size_x_int, -size_x_int,  // up down
@@ -636,7 +636,7 @@ float NodeHybrid::getObstacleHeuristic(
 
     // find neighbors
     for (unsigned int i = 0; i != neighborhood.size(); i++) {
-      new_idx = static_cast<unsigned int>(static_cast<int>(idx) + neighborhood[i]);
+      new_idx = static_cast<uint64_t>(static_cast<int>(idx) + neighborhood[i]);
 
       // if neighbor path is better and non-lethal, set new cost and add to queue
       if (new_idx < size_x * size_y) {
@@ -855,12 +855,13 @@ void NodeHybrid::precomputeDistanceHeuristic(
 }
 
 void NodeHybrid::getNeighbors(
-  std::function<bool(const unsigned int &, nav2_smac_planner::NodeHybrid * &)> & NeighborGetter,
+  std::function<bool(const uint64_t &,
+  nav2_smac_planner::NodeHybrid * &)> & NeighborGetter,
   GridCollisionChecker * collision_checker,
   const bool & traverse_unknown,
   NodeVector & neighbors)
 {
-  unsigned int index = 0;
+  uint64_t index = 0;
   NodePtr neighbor = nullptr;
   Coordinates initial_node_coords;
   const MotionPoses motion_projections = motion_table.getProjections(this);

--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -180,7 +180,7 @@ float & LatticeMotionTable::getAngleFromBin(const unsigned int & bin_idx)
   return lattice_metadata.heading_angles[bin_idx];
 }
 
-NodeLattice::NodeLattice(const unsigned int index)
+NodeLattice::NodeLattice(const uint64_t index)
 : parent(nullptr),
   pose(0.0f, 0.0f, 0.0f),
   _cell_cost(std::numeric_limits<float>::quiet_NaN()),
@@ -469,12 +469,13 @@ void NodeLattice::precomputeDistanceHeuristic(
 }
 
 void NodeLattice::getNeighbors(
-  std::function<bool(const unsigned int &, nav2_smac_planner::NodeLattice * &)> & NeighborGetter,
+  std::function<bool(const uint64_t &,
+  nav2_smac_planner::NodeLattice * &)> & NeighborGetter,
   GridCollisionChecker * collision_checker,
   const bool & traverse_unknown,
   NodeVector & neighbors)
 {
-  unsigned int index = 0;
+  uint64_t index = 0;
   float angle;
   bool backwards = false;
   NodePtr neighbor = nullptr;

--- a/nav2_smac_planner/test/test_node2d.cpp
+++ b/nav2_smac_planner/test/test_node2d.cpp
@@ -142,8 +142,10 @@ TEST(Node2DTest, test_node_2d_neighbors)
   unsigned char cost = static_cast<unsigned int>(1);
   nav2_smac_planner::Node2D * node = new nav2_smac_planner::Node2D(1);
   node->setCost(cost);
-  std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> neighborGetter =
-    [&, this](const unsigned int & index, nav2_smac_planner::Node2D * & neighbor_rtn) -> bool
+  std::function<bool(const uint64_t &,
+    nav2_smac_planner::Node2D * &)> neighborGetter =
+    [&, this](const uint64_t & index,
+      nav2_smac_planner::Node2D * & neighbor_rtn) -> bool
     {
       return false;
     };

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -360,8 +360,10 @@ TEST(NodeHybridTest, test_node_reeds_neighbors)
     std::make_unique<nav2_smac_planner::GridCollisionChecker>(costmap_ros, 72, lnode);
   checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
   nav2_smac_planner::NodeHybrid * node = new nav2_smac_planner::NodeHybrid(49);
-  std::function<bool(const unsigned int &, nav2_smac_planner::NodeHybrid * &)> neighborGetter =
-    [&, this](const unsigned int & index, nav2_smac_planner::NodeHybrid * & neighbor_rtn) -> bool
+  std::function<bool(const uint64_t &,
+    nav2_smac_planner::NodeHybrid * &)> neighborGetter =
+    [&, this](const uint64_t & index,
+      nav2_smac_planner::NodeHybrid * & neighbor_rtn) -> bool
     {
       // because we don't return a real object
       return false;

--- a/nav2_smac_planner/test/test_nodelattice.cpp
+++ b/nav2_smac_planner/test/test_nodelattice.cpp
@@ -303,8 +303,10 @@ TEST(NodeLatticeTest, test_get_neighbors)
     std::make_unique<nav2_smac_planner::GridCollisionChecker>(costmap_ros, 72, lnode);
   checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
 
-  std::function<bool(const unsigned int &, nav2_smac_planner::NodeLattice * &)> neighborGetter =
-    [&, this](const unsigned int & index, nav2_smac_planner::NodeLattice * & neighbor_rtn) -> bool
+  std::function<bool(const uint64_t &,
+    nav2_smac_planner::NodeLattice * &)> neighborGetter =
+    [&, this](const uint64_t & index,
+      nav2_smac_planner::NodeLattice * & neighbor_rtn) -> bool
     {
       // because we don't return a real object
       return false;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory Simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

For huge maps and using a high value for the parameter `angle_quantization_bins`, it is possible to overflow the node index which is using a unsigned 32 bit integer:
https://github.com/ros-planning/navigation2/blob/9f6b0dd3fb61508b1e042eff6deaca3d21d99550/nav2_smac_planner/src/a_star.cpp#L290
For instance for a map of 10813x6743 pixels, and using `angle_quantization_bins: 64`, that gives us 4,666,371,776 which is above 4,294,967,295 (utin32 max).
I tried to only use 64 bit for the index, and not the map x/y size, but that is to discuss as we should then be careful of explicit casting (I got bitten). Hence the draft. And because I tested it only for the hybrid planner.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
