### PR TITLE
Ignore warnings in included xtensor library

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
@@ -17,7 +17,13 @@
 
 #include <memory>
 #include <vector>
+
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_core/goal_checker.hpp"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
@@ -19,7 +19,13 @@
 #include <string>
 #include <vector>
 #include <pluginlib/class_loader.hpp>
+
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/control_sequence.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/control_sequence.hpp
@@ -15,7 +15,12 @@
 #ifndef NAV2_MPPI_CONTROLLER__MODELS__CONTROL_SEQUENCE_HPP_
 #define NAV2_MPPI_CONTROLLER__MODELS__CONTROL_SEQUENCE_HPP_
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 namespace mppi::models
 {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/path.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/path.hpp
@@ -15,7 +15,12 @@
 #ifndef NAV2_MPPI_CONTROLLER__MODELS__PATH_HPP_
 #define NAV2_MPPI_CONTROLLER__MODELS__PATH_HPP_
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 namespace mppi::models
 {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
@@ -15,7 +15,12 @@
 #ifndef NAV2_MPPI_CONTROLLER__MODELS__STATE_HPP_
 #define NAV2_MPPI_CONTROLLER__MODELS__STATE_HPP_
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/trajectories.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/trajectories.hpp
@@ -15,8 +15,13 @@
 #ifndef NAV2_MPPI_CONTROLLER__MODELS__TRAJECTORIES_HPP_
 #define NAV2_MPPI_CONTROLLER__MODELS__TRAJECTORIES_HPP_
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
+#pragma GCC diagnostic pop
 
 namespace mppi::models
 {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -19,10 +19,16 @@
 
 #include "nav2_mppi_controller/models/control_sequence.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
+
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xmath.hpp>
 #include <xtensor/xmasked_view.hpp>
 #include <xtensor/xview.hpp>
 #include <xtensor/xnoalias.hpp>
+#pragma GCC diagnostic pop
 
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -18,8 +18,13 @@
 #include <string>
 #include <memory>
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
+#pragma GCC diagnostic pop
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
@@ -21,8 +21,13 @@
 #include <mutex>
 #include <condition_variable>
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
+#pragma GCC diagnostic pop
 
 #include "nav2_mppi_controller/models/optimizer_settings.hpp"
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
@@ -17,7 +17,13 @@
 
 #include <memory>
 #include <string>
+
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xtensor.hpp>
+#pragma GCC diagnostic pop
 
 #include "nav_msgs/msg/path.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -23,10 +23,15 @@
 #include <memory>
 #include <vector>
 
+// xtensor creates warnings that needs to be ignored as we are building with -Werror
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #include <xtensor/xarray.hpp>
 #include <xtensor/xnorm.hpp>
 #include <xtensor/xmath.hpp>
 #include <xtensor/xview.hpp>
+#pragma GCC diagnostic pop
 
 #include "angles/angles.h"
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Related to #4265  |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | Compile only |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Suppress warnings (which are then treated as errors) from upstream xtensor library

## Description of documentation updates required from your changes

* None

---

## Future work that may be required in bullet points

* None for this particular problem

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
