### PR TITLE
[RotationShimController] rotate also on short paths

### DIFF
--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -195,10 +195,7 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathPt()
     }
   }
 
-  throw nav2_core::ControllerException(
-          std::string(
-            "Unable to find a sampling point at least %0.2f from the robot,"
-            "passing off to primary controller plugin.", forward_sampling_distance_));
+  return current_path_.poses.back();
 }
 
 geometry_msgs::msg::Pose


### PR DESCRIPTION
When the path is shorter than ´forward_sampling_distance´ the rotatitonShimController would directly give control to the primary controller to navigate to the goal. This would lead to the exact behavior that was tried to be fixed by the rotationShimController: "The result is an awkward, stuttering, or whipping around behavior" [1]. It often resulted in navigation failure.

In this case, the controller should try to rotate towards the last point of the path, so that the primary controller can have a better starting orientation.

[1] https://navigation.ros.org/tuning/index.html#rotate-in-place-behavior

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4281  |
| Primary OS tested on | Ubuntu 20.04 / 22.04 |
| Robotic platform tested on | Gazebo simulation - custom hardware |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Let the rotationShimController rotate the robot when the path length is shorter than ´forward_sampling_distance´ (this allow the robot to have the correct orientation when the requested goal is really close)

## Description of documentation updates required from your changes

* Need to update the ´forward_sampling_distance´ description of https://navigation.ros.org/tutorials/docs/using_shim_controller.html --> add "if there is no point further than forward_sampling_distance, rotates toward the goal"
* Same gos for https://navigation.ros.org/configuration/packages/configuring-rotation-shim-controller.html

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
