### PR TITLE
Fix #4268

### DIFF
--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -101,7 +101,7 @@ bool GridCollisionChecker::inCollision(
   if (outsideRange(costmap_->getSizeInCellsX(), x) ||
     outsideRange(costmap_->getSizeInCellsY(), y))
   {
-    return false;
+    return true;
   }
 
   // Assumes setFootprint already set


### PR DESCRIPTION
Fixes a typo in the collision checker in Smac Planner for checking out of bounds requests