### PR TITLE
Update README.md of nav2_bt_navigator

### DIFF
--- a/nav2_bt_navigator/README.md
+++ b/nav2_bt_navigator/README.md
@@ -2,7 +2,7 @@
 
 The BT Navigator (Behavior Tree Navigator) module implements the NavigateToPose and NavigateThroughPoses task interfaces. It is a [Behavior Tree](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/docs/BT_basics.md)-based implementation of navigation that is intended to allow for flexibility in the navigation task and provide a way to easily specify complex robot behaviors.
 
-See its [Configuration Guide Page](https://navigation.ros.org/configuration/packages/configuring-bt-navigator.html) for additional parameter descriptions, as well as the [Nav2 Behavior Tree Explanation](https://navigation.ros.org/behavior_trees/index.html) pages explaining more context on the default behavior trees and examples provided in this package.
+See its [Configuration Guide Page](https://docs.nav2.org/configuration/packages/configuring-bt-navigator.html) for additional parameter descriptions, as well as the [Nav2 Behavior Tree Explanation](https://docs.nav2.org/behavior_trees/index.html) pages explaining more context on the default behavior trees and examples provided in this package.
 
 ## Overview
 


### PR DESCRIPTION
Checking the README of nav2_bt_navigator, realized that the link of the docs ([navigation.ros.org](navigation.ros.org)) are no longer valid. Updating to the valid one ([docs.nav2.org](docs.nav2.org)).

Quite sure others READMEs should be updated as well.
